### PR TITLE
declare global variables as constant in Julia

### DIFF
--- a/src/rlhc-julia.lm
+++ b/src/rlhc-julia.lm
@@ -351,12 +351,12 @@ namespace julia_gen
 		}
 		case [A: static_array] {
 			send Parser
-				"[A.ident] = [type(A.type)] "
+				"const [A.ident] = [type(A.type)] "
 					"\[ [num_list(A.num_list)] \]
 		}
 		case [V: static_value] {
 			send Parser
-				"[V.ident] = [V.number]
+				"const [V.ident] = [V.number]
 		}
 		# case [declaration]
 		case [


### PR DESCRIPTION
In Julia, static global variables should be declared with the `const` keyword if
possible. This is an important hint to the Julia compiler because it will make
type inference work well and hence improve the performance.

This patch was picked from the BioJulia/ragel7 mirror, originally written by
Daniel C. Jones.