### PR TITLE
Simplify comparing against a single character in a flat style.

### DIFF
--- a/src/flat.cc
+++ b/src/flat.cc
@@ -587,21 +587,32 @@ void Flat::LOCATE_TRANS()
 		if ( !limitLow || !limitHigh ) {
 			out << "	if ( ";
 
-			if ( !limitHigh )
-				out << GET_KEY() << " <= " << highKey;
+			if (lowKey != highKey) {
+				if ( !limitLow )
+					out << GET_KEY() << " >= " << lowKey;
 
-			if ( !limitHigh && !limitLow )
-				out << " && ";
+				if ( !limitHigh && !limitLow )
+					out << " && ";
 
-			if ( !limitLow )
-				out << GET_KEY() << " >= " << lowKey;
+				if ( !limitHigh )
+					out << GET_KEY() << " <= " << highKey;
+			}
+			else {
+				out << GET_KEY() << " == " << lowKey;
+			}
 
 			out << " )\n	{\n";
 		}
 
 		out <<
-			"       int _ic = " << CAST("int") << ARR_REF( charClass ) << "[" << GET_KEY() <<
-							" - " << lowKey << "];\n"
+			"       int _ic = " << CAST("int") << ARR_REF( charClass ) << "[" << GET_KEY();
+
+		if (!limitLow) {
+			out << " - " << lowKey;
+		}
+
+		out <<
+			"];\n"
 			"		if ( _ic <= " << CAST("int") << DEREF( ARR_REF( keys ), "_keys+1" ) << " && " <<
 						"_ic >= " << CAST("int") << DEREF( ARR_REF( keys ), "_keys" ) << " )\n"
 			"			_trans = " << CAST("int") << DEREF( ARR_REF( indicies ),

--- a/src/flatvar.cc
+++ b/src/flatvar.cc
@@ -271,21 +271,32 @@ void FlatVar::LOCATE_TRANS()
 		if ( !limitLow || !limitHigh ) {
 			out << "	if ( ";
 
-			if ( !limitHigh )
-				out << GET_KEY() << " <= " << highKey;
+			if (lowKey != highKey) {
+				if ( !limitLow )
+					out << GET_KEY() << " >= " << lowKey;
 
-			if ( !limitHigh && !limitLow )
-				out << " && ";
+				if ( !limitHigh && !limitLow )
+					out << " && ";
 
-			if ( !limitLow )
-				out << GET_KEY() << " >= " << lowKey;
+				if ( !limitHigh )
+					out << GET_KEY() << " <= " << highKey;
+			}
+			else {
+				out << GET_KEY() << " == " << lowKey;
+			}
 
 			out << " )\n	{\n";
 		}
 
 		out <<
-			"       int _ic = " << CAST( "int" ) << ARR_REF( charClass ) << "[" << GET_KEY() <<
-							" - " << lowKey << "];\n"
+			"       int _ic = " << CAST("int") << ARR_REF( charClass ) << "[" << GET_KEY();
+
+		if (!limitLow) {
+			out << " - " << lowKey;
+		}
+
+		out <<
+			"];\n"
 			"		if ( _ic <= " << CAST( "int" ) << DEREF( ARR_REF( keys ), "_keys+1" ) << " && " <<
 						"_ic >= " << CAST( "int" ) << DEREF( ARR_REF( keys ), "_keys" ) << " )\n"
 			"			_trans = " << CAST( UINT() ) << DEREF( ARR_REF( indicies ),


### PR DESCRIPTION
This simplifies branches like

```
if ( ( deref( data, p )) >= 48 && ( deref( data, p )) <= 48 )
```

, which are very common when matching against keywords and other dictionaries, to

```
if ( ( deref( data, p )) == 48 )
```