### PR TITLE
.ri indentation fixes

### DIFF
--- a/src/binexpgoto.cc
+++ b/src/binexpgoto.cc
@@ -434,7 +434,7 @@ void BinaryExpGoto::writeExec()
 	}
 
 	if ( testEofUsed )
-		out << "}\n	" << LABEL( "_test_eof" ) << " { {}\n";
+		out << "}\n" << LABEL( "_test_eof" ) << " {\n";
 
 	if ( redFsm->anyEofTrans() || redFsm->anyEofActions() ) {
 		out <<
@@ -464,10 +464,10 @@ void BinaryExpGoto::writeExec()
 	}
 
 	if ( outLabelUsed )
-		out << "}\n	" << LABEL( "_out" ) << " { {}\n";
+		out << "}\n" << LABEL( "_out" ) << " {\n";
 
 	/* The entry loop. */
-	out << "}}\n";
+	out << "}\n}\n";
 
 	NFA_POP();
 

--- a/src/binloopgoto.cc
+++ b/src/binloopgoto.cc
@@ -448,7 +448,7 @@ void BinaryLoopGoto::writeExec()
 	}
 	
 	if ( testEofUsed )
-		out << "}\n " << LABEL( "_test_eof" ) << " { {}\n";
+		out << "}\n" << LABEL( "_test_eof" ) << " {\n";
 	
 	if ( redFsm->anyEofTrans() || redFsm->anyEofActions() ) {
 		out << 
@@ -487,10 +487,10 @@ void BinaryLoopGoto::writeExec()
 	}
 
 	if ( outLabelUsed )
-		out << "} " << LABEL( "_out" ) << " { {}\n";
+		out << "}\n" << LABEL( "_out" ) << " {\n";
 
 	/* The entry loop. */
-	out << "}}\n";
+	out << "}\n}\n";
 
 	NFA_POP();
 

--- a/src/flatexpgoto.cc
+++ b/src/flatexpgoto.cc
@@ -307,7 +307,7 @@ void FlatExpGoto::writeExec()
 	if ( condSpaceList.length() == 0 )
 		cond = "_trans";
 
-	out << "} " << LABEL( "_match_cond" ) << " {\n";
+	out << "}\n" << LABEL( "_match_cond" ) << " {\n";
 
 	if ( redFsm->anyRegCurStateRef() )
 		out << "	_ps = " << vCS() << ";\n";
@@ -343,7 +343,7 @@ void FlatExpGoto::writeExec()
 
 	if ( redFsm->anyRegActions() || redFsm->anyActionGotos() || 
 			redFsm->anyActionCalls() || redFsm->anyActionRets() )
-		out << "} " << LABEL( "_again" ) << " {\n";
+		out << "}\n" << LABEL( "_again" ) << " {\n";
 
 	if ( redFsm->anyToStateActions() ) {
 		out <<
@@ -373,7 +373,7 @@ void FlatExpGoto::writeExec()
 	}
 
 	if ( testEofUsed )
-		out << "} " << LABEL( "_test_eof" ) << " { {}\n";
+		out << "}\n" << LABEL( "_test_eof" ) << " {\n";
 
 	if ( redFsm->anyEofTrans() || redFsm->anyEofActions() ) {
 		out <<
@@ -408,12 +408,12 @@ void FlatExpGoto::writeExec()
 	}
 
 	if ( outLabelUsed )
-		out << "} " << LABEL( "_out" ) << " { {}\n";
+		out << "}\n" << LABEL( "_out" ) << " {\n";
 
 	/* The entry loop. */
-	out << "}}\n";
+	out << "}\n}\n";
 
 	NFA_POP();
 
-	out << "	}\n";
+	out << "}\n";
 }

--- a/src/flatloopgoto.cc
+++ b/src/flatloopgoto.cc
@@ -267,7 +267,7 @@ void FlatLoopGoto::writeExec()
 	if ( condSpaceList.length() == 0 )
 		cond = "_trans";
 
-	out << "} " << LABEL( "_match_cond" ) << " {\n";
+	out << "}\n" << LABEL( "_match_cond" ) << " {\n";
 
 	if ( redFsm->anyRegCurStateRef() )
 		out << "	_ps = " << vCS() << ";\n";
@@ -312,7 +312,7 @@ void FlatLoopGoto::writeExec()
 
 	if ( redFsm->anyRegActions() || redFsm->anyActionGotos() || 
 			redFsm->anyActionCalls() || redFsm->anyActionRets() )
-		out << "} " << LABEL( "_again" ) << " {\n";
+		out << "}\n" << LABEL( "_again" ) << " {\n";
 
 	if ( redFsm->anyToStateActions() ) {
 		out <<
@@ -348,7 +348,7 @@ void FlatLoopGoto::writeExec()
 	}
 
 	if ( testEofUsed )
-		out << "} " << LABEL( "_test_eof" ) << " { {}\n";
+		out << "}\n" << LABEL( "_test_eof" ) << " {\n";
 
 	if ( redFsm->anyEofTrans() || redFsm->anyEofActions() ) {
 		out << 
@@ -391,10 +391,10 @@ void FlatLoopGoto::writeExec()
 	}
 
 	if ( outLabelUsed )
-		out << "} " << LABEL( "_out" ) << " { {}\n";
+		out << "}\n" << LABEL( "_out" ) << " {\n";
 
 	/* The entry loop. */
-	out << "}}\n";
+	out << "}\n}\n";
 
 	NFA_POP();
 

--- a/src/rlhc-c.lm
+++ b/src/rlhc-c.lm
@@ -460,7 +460,9 @@ namespace c_gen
 		{
 			send Parser
 				"[Stmt.label_stmt.ident]:
+				"{
 				"[stmt_list( Stmt.label_stmt._repeat_stmt )]
+				"}
 		}
 		case [entry_loop]
 		{


### PR DESCRIPTION
This PR simply fixes formatting / indentation in temporary `.ri` files. This doesn't affect functionality in any way, but simplifies debugging a little bit as those temporary files are often reviewed manually in order to understand which syntactic construction are not matched / not generated properly / etc.