### PR TITLE
Fix Julia syntax

### DIFF
--- a/src/rlhc-julia.lm
+++ b/src/rlhc-julia.lm
@@ -9,7 +9,7 @@ namespace julia_out
 			'/*' any* :>> '*/'
 		/
 
-		literal `function `end `while `if `else `elseif
+		literal `function `end `while `if `else `elseif `begin
 
 		token id
 			/[a-zA-Z_][a-zA-Z_0-9]*/
@@ -38,6 +38,7 @@ namespace julia_out
 	def kw
 		[`function _IN_]
 	|	[`while _IN_]
+	|	[`begin _IN_]
 	|	[`if _IN_]
 	|	[_EX_ `elseif _IN_]
 	|	[_EX_ `else _IN_]

--- a/src/rlhc-julia.lm
+++ b/src/rlhc-julia.lm
@@ -506,6 +506,11 @@ namespace julia_gen
 			send Parser
 				"@goto [G.ident]
 		}
+		case [break_stmt]
+		{
+			send Parser
+				"break
+		}
 		case [entry_loop]
 		{
 			send Parser

--- a/src/rlhc-julia.lm
+++ b/src/rlhc-julia.lm
@@ -409,28 +409,23 @@ namespace julia_gen
 				"end
 		}
 		case [`switch `( SwitchExpr: expr `) `{ StmtList: stmt* `}] {
-
 			require StmtList
-				[`case E1: expr `{ Inner: stmt* `} Rest: stmt*]
+				[`case E1: expr `: Rest: stmt*]
 
 			send Parser
 				"if [expr(SwitchExpr)] == [expr(E1)]
-				"	[stmt_list(Inner)]
 
 			for S: stmt in repeat(Rest) {
 				switch S
-				case [`case E1: expr `{ Inner: stmt* `}]
-				{
+				case [`case E1: expr `:] {
 					send Parser
 						"elseif [expr(SwitchExpr)] == [expr(E1)]
-						"	[stmt_list(Inner)]
 				}
-				case
-					[`default `{ Inner: stmt* `}]
-				{
-					send Parser
-						"else
-						"	[stmt_list(Inner)]
+				case [break_stmt] {
+					# do not emit the `break` statement
+				}
+				default {
+					stmt(S)
 				}
 			}
 


### PR DESCRIPTION
I don't know when but the current Julia code generated from Ragel is broken. This is a patch to fix the generator of Julia and now it works well in my non-trivial programs.